### PR TITLE
try fix vue template linting (wip)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 import typescriptEslint from 'typescript-eslint'
-import prettier from 'eslint-config-prettier'
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 import pluginVue from 'eslint-plugin-vue'
 import js from '@eslint/js'
 
@@ -28,5 +28,5 @@ export default [
       '@typescript-eslint/no-explicit-any': 'off',
     }
   },
-  prettier
+  eslintPluginPrettierRecommended,
 ]

--- a/package.json
+++ b/package.json
@@ -12,6 +12,5 @@
     "prettier": "^3.3.3",
     "prettier-config-standard": "^7.0.0",
     "typescript-eslint": "^8.3.0"
-  },
-  "prettier": "prettier-config-standard"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-vue": "^9.27.0",
     "prettier": "^3.3.3",
     "prettier-config-standard": "^7.0.0",
     "typescript-eslint": "^8.3.0"
-  }
+  },
+  "prettier": "prettier-config-standard"
 }


### PR DESCRIPTION
- eslint-config-prettier just somehow disables *any* linting of vue `<template>` it seems to belong to .eslintrc legacy times?
- unfortunately, as-is, this introduces a lot of errors: ~3k at current froide, mostly missing semicolons...
- going by the old setup (pre-new-tooling), i would expect the number to be somewhere 0<n<10
- not limited to, but including notably lots of irregular indentation, which used to produce errors (not warnings!). from reading the old code i can't tell if this was ever intentional though 😅 ...but i grew to like it
- in general, it feels like prettier doesn't like to coexist with other linter plugins?